### PR TITLE
set type to 'http' to invoke http-ish behavior

### DIFF
--- a/lib/client/core.js
+++ b/lib/client/core.js
@@ -125,7 +125,8 @@ function WorkerPouch(opts, callback) {
   }
 
   api.type = function () {
-    return 'worker';
+    // see https://github.com/pouchdb/pouchdb/issues/6106
+    return 'http';
   };
 
   api._id = adapterFun('id', function (callback) {


### PR DESCRIPTION
One good way to test interop issues with https://github.com/pouchdb/pouchdb/issues/6106 is to just change the `type()` to `'http'` and see if the tests still pass.

If they do, this is a reasonable change for interop reasons, even if it doesn't make much logical sense. The goal is just to invoke PouchDB behavior that is optimized for remote adapters, i.e. adapters where it's expensive to cross some kind of boundary (http, web sockets, worker, etc.).