### PR TITLE
keep worker field as Worker (type) when cloning opts

### DIFF
--- a/lib/shared/pouchdb-clone.js
+++ b/lib/shared/pouchdb-clone.js
@@ -15,8 +15,8 @@ function isPlainObject(value) {
     return true;
   }
   var Ctor = proto.constructor;
-  return (typeof Ctor == 'function' &&
-    Ctor instanceof Ctor && funcToString.call(Ctor) == objectCtorString);
+  return (typeof Ctor === 'function' &&
+    Ctor instanceof Ctor && funcToString.call(Ctor) === objectCtorString);
 }
 
 function cloneArrayBuffer(buff) {

--- a/lib/shared/pouchdb-clone.js
+++ b/lib/shared/pouchdb-clone.js
@@ -5,6 +5,20 @@ function isBinaryObject(object) {
     (typeof Blob !== 'undefined' && object instanceof Blob);
 }
 
+var funcToString = Function.prototype.toString;
+var objectCtorString = funcToString.call(Object);
+
+function isPlainObject(value) {
+  var proto = Object.getPrototypeOf(value);
+  /* istanbul ignore if */
+  if (proto === null) { // not sure when this happens, but I guess it can
+    return true;
+  }
+  var Ctor = proto.constructor;
+  return (typeof Ctor == 'function' &&
+    Ctor instanceof Ctor && funcToString.call(Ctor) == objectCtorString);
+}
+
 function cloneArrayBuffer(buff) {
   if (typeof buff.slice === 'function') {
     return buff.slice(0);
@@ -50,6 +64,10 @@ module.exports = function clone(object) {
 
   if (isBinaryObject(object)) {
     return cloneBinaryObject(object);
+  }
+
+  if (!isPlainObject(object)) {
+    return object; // don't clone objects like Workers
   }
 
   newObject = {};


### PR DESCRIPTION
Hi, a little PR for allowing Custom mode without : "Error: you must provide a valid `worker` in `new PouchDB()`"